### PR TITLE
Token comparison callback for MyersDiff (issue 7)

### DIFF
--- a/src/MyersDiff.php
+++ b/src/MyersDiff.php
@@ -111,11 +111,16 @@ class MyersDiff
      *
      * @param string[] $a - tokens (characters, words or lines)
      * @param string[] $b - tokens (characters, words or lines)
+     * @param function $compare - comparison function for tokens. Signature is compare($x, $y):bool. If null, === is used.
      *
      * @return array[] - pairs of token and edit (-1 for delete, 0 for keep, +1 for insert)
      */
-    public function calculate(array $a, array $b)
+    public function calculate(array $a, array $b, $compare = null)
     {
+        if ($compare === null) {
+            $compare = static function ($x, $y) { return $x === $y; };
+        }
+
         // The algorithm uses array keys numbered from zero.
         $n = count($a);
         $m = count($b);
@@ -141,7 +146,7 @@ class MyersDiff
                 // Derive Y from X.
                 $y = $x - $k;
                 // Follow the diagonal.
-                while ($x < $n && $y < $m && $a[$x] === $b[$y]) {
+                while ($x < $n && $y < $m && $compare($a[$x], $b[$y])) {
                     $x++;
                     $y++;
                 }

--- a/tests/MyersDiffTest.php
+++ b/tests/MyersDiffTest.php
@@ -233,4 +233,24 @@ class MyersDiffTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($diff, $algorithm->calculate($x, $y));
     }
+
+    /**
+     * Test custom token comparison.
+     *
+     * @return void
+     */
+    public function testCustomCompare()
+    {
+        $algorithm = new MyersDiff();
+        $ignorecase = static function ($x, $y) { return strtolower($x) === strtolower($y); };
+        $x = array('a', 'b', 'c');
+        $y = array('A', 'B', 'C');
+        $diff = array(
+            array('a', MyersDiff::KEEP),
+            array('b', MyersDiff::KEEP),
+            array('c', MyersDiff::KEEP),
+        );
+
+        $this->assertSame($diff, $algorithm->calculate($x, $y, $ignorecase));
+    }
 }


### PR DESCRIPTION
This is relating to #7.

I’ve modified  _MyersDiff::calculate_ to accept an optional callback for token comparison. I’ve added a unit test as well (_MyersDiffTest::testCustomCompare_) relating to this feature.